### PR TITLE
Fix Gitpod setup

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,5 +1,5 @@
-FROM gitpod/workspace-mysql:branch-mysql
+FROM gitpod/workspace-mysql
 
-# install python3-dev to make sure the pip package "mysqlclient" works fine.
-USER root
-RUN apt-get update && apt-get install -y pkg-config python3-dev
+# Install and set up Python 3.6 (required by this project)
+RUN pyenv install 3.6.10 && pyenv global 3.6.10 && \
+    pip install virtualenv pipenv pylint rope flake8 autopep8 pep8 pylama pydocstyle bandit notebook python-language-server[all]==0.25.0

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,14 +6,18 @@ ports:
     - port: 3306
       onOpen: ignore
 tasks:
-    - init: >
-        cp .env.example .env;
-        pipenv install;
-        mysql -u root -e "CREATE DATABASE example";
-        pipenv run init;
-        pipenv run migrate;
-        pipenv run upgrade;
-      command: >
-        pipenv run start;
+    - init: |
+        set -x
+        cp .env.example .env
+        pipenv install
+        mysql -u root -e "CREATE DATABASE example"
+        pipenv run init
+        pipenv run migrate
+        pipenv run upgrade
+        set +x
+      command: |
+        set -x
+        pipenv run start
+        set +x
     - command: python3 welcome.py
       openMode: split-right


### PR DESCRIPTION
Hi @zeethecoder!

Thank you for reporting https://github.com/gitpod-io/gitpod/issues/1285.

I took a look at your Gitpod setup, and found a few problems:

- The base image was `gitpod/workspace-mysql:branch-mysql` instead of `:latest`, i.e. it was using a 9-months-old temporary development tag

- The `pkg-config` and `python3-dev` installs seemed unnecessary, so I've removed them (please let me know if they shouldn't be removed)

- I've installed Python 3.6 in your Dockerfile, because that's what your `Pipfile` and `Pipfile.lock` seem to want, but Gitpod ships with Python 3.7 by default

- I've enabled extra debugging logs in your `.gitpod.yml` tasks

This set-up now seems to mostly work:

<img width="1440" alt="Screenshot 2020-03-03 at 17 58 28" src="https://user-images.githubusercontent.com/599268/75799687-b279b200-5d78-11ea-9a82-e175ad76fc81.png">

However, the left Terminal shows a few errors that seem a bit worrying:

```
+ pipenv run init
Loading .env environment variables…
Error: Directory migrations already exists and is not empty
```

```
+ pipenv run migrate
Loading .env environment variables…
INFO  [alembic.runtime.migration] Context impl MySQLImpl.
[...]
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/gugs/migrations/versions'
```

Hope this helps! Please let me know if you have any questions, or if you'd like me to make some changes to this PR.